### PR TITLE
improve output of statistics at the end

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -252,12 +252,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             FileCheckResult::Unmodifed(_) | FileCheckResult::Missing(_) => false,
                         })
                         .count();
+                    println!("└ {} files not found in archive", not_present);
                     if not_present > 0 {
-                        return Err(anyhow::Error::msg(format!(
-                            "{} files not found in archive",
-                            not_present
-                        ))
-                        .into());
+                        return Err(anyhow::Error::msg("files not found in archive").into());
                     }
                 }
                 (true, false) => {
@@ -270,11 +267,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .iter()
                         .filter(|f| matches!(f, FileCheckResult::New(_)))
                         .count();
-                    if missing_or_modified > 0 {
-                        return Err(anyhow::Error::msg(format!(
-                            "{} files changed, {} files not found in archive",
-                            missing_or_modified, new
-                        ))
+                    println!("└ {} files modified", missing_or_modified);
+                    println!("└ {} files not found in archive", new);
+                    if missing_or_modified > 0 || new > 0 {
+                        return Err(anyhow::Error::msg(
+                            "files modified or files not found in archive",
+                        )
                         .into());
                     }
                 }
@@ -304,12 +302,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             _ => {}
                         }
                     }
+                    println!("└ {} files not found in archive", not_present);
+                    println!("└ {} files in archive not found", missing_sha256.len());
                     if not_present > 0 || !missing_sha256.is_empty() {
-                        return Err(anyhow::Error::msg(format!(
-                            "{} files not found in archive, {} files in archive not found",
-                            not_present,
-                            missing_sha256.len()
-                        ))
+                        return Err(anyhow::Error::msg(
+                            "files not found in archive and / or files in archive not found",
+                        )
                         .into());
                     }
                 }
@@ -328,11 +326,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .iter()
                         .filter(|f| matches!(f, FileCheckResult::New(_)))
                         .count();
+                    println!("└ {} files missing or modified", missing_or_modified);
+                    println!("└ {} files not found in archive", new);
+
                     if missing_or_modified > 0 || new > 0 {
-                        return Err(anyhow::Error::msg(format!(
-                            "{} files missing or changed, {} files not found in archive",
-                            missing_or_modified, new
-                        ))
+                        return Err(anyhow::Error::msg(
+                            "files missing, modified and / or not found in archive",
+                        )
                         .into());
                     }
                 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,4 +1,3 @@
-use std::cmp::max;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -76,79 +75,39 @@ impl StatsCollector {
     }
     pub fn print_results_for_update(&self, duration: Duration, newly_missing: u64) {
         let r = self.get_results();
-        let prec_1 = (max(r.files_checked, r.files_unchanged) as f64)
-            .log10()
-            .ceil() as usize;
-        println!(
-            "{:prec$} files checked in {:.1?}:",
-            r.files_checked,
-            duration,
-            prec = prec_1
-        );
+        println!("{} files checked in {:.1?}:", r.files_checked, duration,);
 
-        let prec_2 = (max(r.files_read, r.files_not_found) as f64).log10().ceil() as usize;
         println!(
-            "    {:prec$} files read ({:.1} GiB, {:.0} MiB/s):",
+            "└ {} files read ({:.1} GiB, {:.0} MiB/s):",
             r.files_read,
             (r.bytes_read as f64) / 1024.0 / 1024.0 / 1024.0,
             (r.bytes_read as f64) / 1024.0 / 1024.0 / duration.as_secs_f64(),
-            prec = prec_2
         );
 
-        let prec_3 = (max(
-            max(r.files_new, r.files_modified),
-            max(r.files_duplicate_removed, newly_missing),
-        ) as f64)
-            .log10()
-            .ceil() as usize;
-        println!("        {:prec$} new files", r.files_new, prec = prec_3);
+        println!("  └ {} new files", r.files_new);
+        println!("  └ {} files modified", r.files_modified,);
+        println!("└ {} files not found:", r.files_not_found,);
         println!(
-            "        {:prec$} files modified",
-            r.files_modified,
-            prec = prec_3
-        );
-        println!(
-            "    {:prec$} files not found:",
-            r.files_not_found,
-            prec = prec_2
-        );
-        println!(
-            "        {:prec$} files found elsewhere (moved or duplicates removed)",
+            "  └ {} files found elsewhere (moved or duplicates removed)",
             r.files_duplicate_removed,
-            prec = prec_3
         );
+        println!("  └ {} files newly missing", newly_missing,);
         println!(
-            "        {:prec$} files newly missing",
-            newly_missing,
-            prec = prec_3
-        );
-        println!(
-            "{:prec$} files unchanged ({:.1} GiB)",
+            "{} files unchanged ({:.1} GiB)",
             r.files_unchanged,
             r.files_unchanged_size as f64 / 1024.0 / 1024.0 / 1024.0,
-            prec = prec_1
         );
     }
 
     pub(crate) fn print_results_for_verify(&self, duration: Duration) {
         let r = self.get_results();
-        let prec_1 = (max(r.files_checked, r.files_unchanged) as f64)
-            .log10()
-            .ceil() as usize;
-        println!(
-            "{:prec$} files checked in {:.1?}:",
-            r.files_checked,
-            duration,
-            prec = prec_1
-        );
+        println!("{} files checked in {:.1?}:", r.files_checked, duration,);
 
-        let prec_2 = (max(r.files_read, r.files_not_found) as f64).log10().ceil() as usize;
         println!(
-            "    {:prec$} files read ({:.1} GiB, {:.0} MiB/s):",
+            "└ {} files read ({:.1} GiB, {:.0} MiB/s)",
             r.files_read,
             (r.bytes_read as f64) / 1024.0 / 1024.0 / 1024.0,
             (r.bytes_read as f64) / 1024.0 / 1024.0 / duration.as_secs_f64(),
-            prec = prec_2
         );
     }
 }


### PR DESCRIPTION
before:
```
389217 files checked in 915.3s:
    130697 files read (72.1 GiB, 81 MiB/s):
        0 new files
        0 files modified
         0 files not found:
        0 files found elsewhere (moved or duplicates removed)
        0 files newly missing
389217 files unchanged (337.9 GiB)
```

after:
```
389217 files checked in 915.3s:
└ 0 files read (72.1 GiB, 81 MiB/s):
  └ 0 new files
  └ 0 files modified
└ 0 files not found:
  └ 0 files found elsewhere (moved or duplicates removed)
  └ 0 files newly missing
389217 files unchanged (337.9 GiB)
```